### PR TITLE
Literaturverzeichnis bug fix

### DIFF
--- a/example/DEMO-TUDaBibliography.bib
+++ b/example/DEMO-TUDaBibliography.bib
@@ -7,7 +7,7 @@
 	urldate = {2018-12-20},
 }
 
-@online{scrguide,
+@online{koma,
 	title={KOMA-Script},
 	subtitle={Die Anleitung},
 	author={Kohm, Markus},

--- a/example/DEMO-TUDaPhD.tex
+++ b/example/DEMO-TUDaPhD.tex
@@ -34,7 +34,8 @@
 %%%%%%%%%%%%%%%%%%%
 %Literaturverzeichnis
 %%%%%%%%%%%%%%%%%%%
-\usepackage{biblatex}   % Literaturverzeichnis
+\usepackage[backend=biber]{biblatex} % Literaturverzeichnis
+%verwende backend=bibtex, wenn kein biber zur Verfügung steht
 \bibliography{DEMO-TUDaBibliography}
 
 

--- a/example/DEMO-TUDaPub.tex
+++ b/example/DEMO-TUDaPub.tex
@@ -7,7 +7,11 @@
 \usepackage[english, main=ngerman]{babel}
 \usepackage[babel]{csquotes}
 
-\usepackage{biblatex}
+%%%%%%%%%%%%%%%%%%%
+%Literaturverzeichnis
+%%%%%%%%%%%%%%%%%%%
+\usepackage[backend=biber]{biblatex} % Literaturverzeichnis
+%verwende backend=bibtex, wenn kein biber zur Verfügung steht
 \bibliography{DEMO-TUDaBibliography}
 
 %Formatierungen für Beispiele in diesem Dokument. Im Allgemeinen nicht notwendig!

--- a/example/DEMO-TUDaThesis.tex
+++ b/example/DEMO-TUDaThesis.tex
@@ -30,7 +30,8 @@
 %%%%%%%%%%%%%%%%%%%
 %Literaturverzeichnis
 %%%%%%%%%%%%%%%%%%%
-\usepackage{biblatex}   % Literaturverzeichnis
+\usepackage[backend=biber]{biblatex} % Literaturverzeichnis
+%verwende backend=bibtex, wenn kein biber zur Verfügung steht
 \bibliography{DEMO-TUDaBibliography}
 
 


### PR DESCRIPTION
1. Ändere handle von bibtex-item in .bib-Datei der DEMO-Dokumente, sodass es zum Dokument passt (vorher wurde Zitation nicht gefunden).
2. Kommentar zur Verwendung von bibtex vs biblatex in Bespiel-Dateien DEMO-{PhD,Pub,Thesis}.