### PR TITLE
example: fix typo

### DIFF
--- a/example/DEMO-TUDaPhD.tex
+++ b/example/DEMO-TUDaPhD.tex
@@ -249,7 +249,7 @@ Es stehen die folgenden Werte zur Verfügung (die Werte in Klammern sind die not
 \item \code{master}: Masterarbeit (title, author, submissiondate, department, reviewer)
 \item \code{pp}: Project-Proposal  (title, author, date, department)
 \item \code{dr}: vorgelegte Dissertation (title, author, submissiondate , birthplace, department, reviewer)
-\item \code{drfinal}: genehmighte Dissertation (title, author, submissiondate,examdate, birthplace, department, reviewer)
+\item \code{drfinal}: genehmigte Dissertation (title, author, submissiondate,examdate, birthplace, department, reviewer)
 \end{itemize}
 Wird ein Typus angegeben, der nicht erkannt wird, so wird der Text direkt übergeben. Notwendige Titelfelder über den Titel hinaus gibt es in diesem Fall nicht.
 \item[dr=<Kürzel>] Lädt einen der vordefinierten Texte für die Titelseite. Als Werte stehen bislang \code{rernat}, \code{ing} und \code{phil} zur Verfügung. Zum Beispiel lädt der Wert \code{phil}:

--- a/example/DEMO-TUDaThesis.tex
+++ b/example/DEMO-TUDaThesis.tex
@@ -231,7 +231,7 @@ Im folgenden findet sich die Bedeutung der einzelnen Optionen:
 		\item \code{master}: Masterarbeit (title, author, submissiondate, department, reviewer)
 		\item \code{pp}: Project-Proposal  (title, author, date, department)
 		\item \code{dr}: vorgelegte Dissertation (title, author, submissiondate , birthplace, department, reviewer)
-		\item \code{drfinal}: genehmighte Dissertation (title, author, submissiondate,examdate, birthplace, department, reviewer)
+		\item \code{drfinal}: genehmigte Dissertation (title, author, submissiondate,examdate, birthplace, department, reviewer)
 	\end{itemize}
 	Wird ein Typus angegeben, der nicht erkannt wird, so wird der Text direkt übergeben. Notwendige Titelfelder über den Titel hinaus gibt es in diesem Fall nicht.	
 	\item[dr=<Kürzel>] Lädt einen der vordefinierten Texte für die Titelseite. Als Werte stehen bislang \code{rernat}, \code{ing} und \code{phil} zur Verfügung. Zum Beispiel lädt der Wert \code{phil}:


### PR DESCRIPTION
genehmighte -> genehmigte