### PR TITLE
Added documentation of implemented colors to TUDaPub

### DIFF
--- a/example/DEMO-TUDaPub.tex
+++ b/example/DEMO-TUDaPub.tex
@@ -219,10 +219,8 @@ entsprechende Labels generiert werden. Sie haben den Namen \code{IMRAD:<Schlüss
 
 Der Prüfmechanismus ist auf Wunsch der Bibliothek standardmäßig aktiviert, kann jedoch durch die Option \code{IMRAD=false} deaktiviert werden.
 
-\subsection{Benutzung der Farben des Coorperate Designs und PGFPlots}
+\subsection{Benutzung der Farben des Coorperate Designs}
 Möchte man die durch das Cooperate Design vorgegebenen Farben nutzen so stehen diese auch im Rahmen dieses Paketes zur Verfügung. Die Benennung folgt dabei dem folgenden Prinzip: \code{TUDa-\#\#}, wobei \code{\#\#} jeweils für den dokumentierten Farbcode steht. 
-
-Falls zur Erstellung von Graphen das Package \code{pgfplots} genutzt wird, werden mit dem Package \code{tuda-pgfplots} die folgenden Stile mitgeliefert, die sich auch auf die vorgegebenen Farben begrenzen: \code{tuda3dplot}, \code{tudalineplot}, \code{tudabarplot}, \code{horizontal tudabarplot}. Außerdem werden die colormaps \code{tudaa}, \code{tudab}, \code{tudac} und \code{tudad} bereitgestellt.
 
 
 \section{Erweiterte Konfigurationsmöglichkeiten}

--- a/example/DEMO-TUDaPub.tex
+++ b/example/DEMO-TUDaPub.tex
@@ -219,6 +219,11 @@ entsprechende Labels generiert werden. Sie haben den Namen \code{IMRAD:<Schlüss
 
 Der Prüfmechanismus ist auf Wunsch der Bibliothek standardmäßig aktiviert, kann jedoch durch die Option \code{IMRAD=false} deaktiviert werden.
 
+\subsection{Benutzung der Farben des Coorperate Designs und PGFPlots}
+Möchte man die durch das Cooperate Design vorgegebenen Farben nutzen so stehen diese auch im Rahmen dieses Paketes zur Verfügung. Die Benennung folgt dabei dem folgenden Prinzip: \code{TUDa-\#\#}, wobei \code{\#\#} jeweils für den dokumentierten Farbcode steht. 
+
+Falls zur Erstellung von Graphen das Package \code{pgfplots} genutzt wird, werden mit dem Package \code{tuda-pgfplots} die folgenden Stile mitgeliefert, die sich auch auf die vorgegebenen Farben begrenzen: \code{tuda3dplot}, \code{tudalineplot}, \code{tudabarplot}, \code{horizontal tudabarplot}. Außerdem werden die colormaps \code{tudaa}, \code{tudab}, \code{tudac} und \code{tudad} bereitgestellt.
+
 
 \section{Erweiterte Konfigurationsmöglichkeiten}
 


### PR DESCRIPTION
Da ich keine Dokumentation der Namen der Farben gefunden habe, habe ich mal eine section dazu in die Dokumentation eingefügt. Dabei habe ich gemerkt, dass auch PGFPlots mit Presets versorgt wurde und habe das gleich mitdokumentiert.