### PR TITLE
Fixed an issue regarding old l3 kernels

### DIFF
--- a/tex/tudathesis.cfg
+++ b/tex/tudathesis.cfg
@@ -562,7 +562,7 @@ Bei einer Thesis des Fachbereichs Architektur entspricht die eingereichte elektr
 
 % Fallback mechanism for older l3 kernels
 \cs_if_exist:NF \text_titlecase:n {
-	\cs_set_eq:NN\text_titlecase:n\tl_mixed_case:n
+	\cs_set_eq:NN \text_titlecase:n \tl_mixed_case:n
 }
 
 \endinput


### PR DESCRIPTION
When using an older l3 kernel, latex was complaining about the control sequence "text_titelcase:n" being undefined. 

In tudathesis.cfg there actually is an alias defined to account for this, but appears not be honored though. 
Adding whitespace fixed the issue. 

