### PR TITLE
Fix typo: Coporate should be Corporate

### DIFF
--- a/tex/tudaexercise.cls
+++ b/tex/tudaexercise.cls
@@ -1,7 +1,7 @@
 \NeedsTeXFormat{LaTeX2e}
 \RequirePackage{expl3}
 \ProvidesExplClass{tudaexercise}
-	{\filedate}{\fileversion}{Exercise sheets and exams using TU Darmstadt's Coporate Desing (TUDa-CI)}
+	{\filedate}{\fileversion}{Exercise sheets and exams using TU Darmstadt's Corporate Desing (TUDa-CI)}
 
 \RequirePackage{l3keys2e}
 

--- a/tex/tudapub.cls
+++ b/tex/tudapub.cls
@@ -1,7 +1,7 @@
 \NeedsTeXFormat{LaTeX2e}
 \RequirePackage{expl3}
 \ProvidesExplClass{tudapub}
-	{\filedate}{\fileversion}{Publications using TU Darmstadt's Coporate Design (TUDa-CI)}
+	{\filedate}{\fileversion}{Publications using TU Darmstadt's Corporate Design (TUDa-CI)}
 
 \RequirePackage{l3keys2e}
 \RequirePackage{URspecialopts}

--- a/tex/tudathesis.cfg
+++ b/tex/tudathesis.cfg
@@ -1,6 +1,6 @@
 \RequirePackage{expl3}
 \ProvidesExplFile{tudathesis.cfg}
-{\filedate}{\fileversion}{Special Features for publication type 'thesis' using TU Darmstadt's Coporate Design (tuda-ci)}
+{\filedate}{\fileversion}{Special Features for publication type 'thesis' using TU Darmstadt's Corporate Design (tuda-ci)}
 
 \RequirePackage{l3keys2e}
 


### PR DESCRIPTION
For once, I actually looked through the logs :D

I noticed there is a minor typo, `Coporate` should probably be `Corporate` I think?