### PR TITLE
Add DOI number to \tuprints command

### DIFF
--- a/example/DEMO-TUDaPhD.tex
+++ b/example/DEMO-TUDaPhD.tex
@@ -92,7 +92,7 @@
 
 \submissiondate{\today}
 \examdate{\today}
-\tuprints{urn=1234,printid=12345}
+\tuprints{urn=1234,printid=12345,doiid=10.25534/tuprints-1234}
 
 \dedication{For \TeX{} \& Friends}
 
@@ -200,7 +200,7 @@ Es ist zu beachten, dass für die Erzeugung der Titelseite nach Übergabe aller 
 	\item[publishers] Wird hier für die Ortsangabe verwendet und ist mit \enquote{Darmstadt}, bzw. \enquote{Darmstadt -- D17} (bei Dissertationen) vorbelegt.
 	\item[tuprints] \label{page:tuprints}Übergabe der Daten, sofern das dokument über tuprints Veröffentlicht werden soll.
 	\begin{verbatim}
-	\tuprints{urn=1234, printid=12345}
+	\tuprints{urn=1234, printid=12345, doiid=10.25534/tuprints-1234}
 	\end{verbatim}
 	Falls das Argument kein Gleichheitszeichen erkennt, wird der Wert als \code{printid} gesetzt und keine URN angegeben.
 

--- a/example/DEMO-TUDaThesis.tex
+++ b/example/DEMO-TUDaThesis.tex
@@ -81,7 +81,7 @@
 \submissiondate{\today}
 \examdate{\today}
 
-%	\tuprints{urn=1234,printid=12345}
+%	\tuprints{urn=1234,printid=12345,doiid=10.25534/tuprints-1234}
 %	\dedication{Für alle, die \TeX{} nutzen.}
 
 \maketitle
@@ -173,7 +173,7 @@ Es ist zu beachten, dass für die Erzeugung der Titelseite nach Übergabe aller 
 	\item[publishers] Wird hier für die Ortsangabe verwendet und ist mit \enquote{Darmstadt}, bzw. \enquote{Darmstadt -- D17} (bei Dissertationen) vorbelegt.
 	\item[tuprints] \label{page:tuprints}Übergabe der Daten, sofern das dokument über tuprints Veröffentlicht werden soll.
 	\begin{verbatim}
-	\tuprints{urn=1234, printid=12345}
+	\\tuprints{urn=1234, printid=12345, doiid=10.25534/tuprints-1234}
 	\end{verbatim}
 	Falls das Argument kein Gleichheitszeichen erkennt, wird der Wert als \code{printid} gesetzt und keine URN angegeben.
 

--- a/tex/tudathesis.cfg
+++ b/tex/tudathesis.cfg
@@ -259,6 +259,7 @@
 	urn .initial:V = \c_empty_tl,
 	printid .tl_gset:N = \g_TUDa_thesis_tuprints_tl,
 	printid .initial:V = \c_empty_tl,
+	doiid .tl_gset:N = \g_TUDa_thesis_tuprints_doi_tl,
 	license .tl_gset:N =  \g_TUDa_license_info_tl,
 	license .initial:n = {Die~Veröffentlichung~steht~unter~folgender~Creative~Commons~Lizenz:\\
 		Namensnennung~--~Keine~kommerzielle~Nutzung~--~Keine~Bearbeitung~ 2.0~Deutschland\\
@@ -273,8 +274,9 @@
   \lowertitleback{
   	\urlstyle{same}
   	Bitte~zitieren~Sie~dieses~Dokument~als:
-    \tl_if_empty:NF \g_TUDa_thesis_urn_tl {\\URN:~urn:nbn:de:tuda-tuprints-\g_TUDa_thesis_urn_tl}
-    \\URL:~\url{http://tuprints.ulb.tu-darmstadt.de/\g_TUDa_thesis_tuprints_tl}\par\vspace{\baselineskip}
+    \tl_if_empty:NF \g_TUDa_thesis_urn_tl {\\URN:~urn:nbn:de:tuda-tuprints-\g_TUDa_thesis_urn_tl}\\
+    URL:~\url{http://tuprints.ulb.tu-darmstadt.de/\g_TUDa_thesis_tuprints_tl}\\
+	DOI:~\url{https://doi.org/\g_TUDa_thesis_tuprints_doi_tl}\par\vspace{\baselineskip}
     Dieses~Dokument~wird~bereitgestellt~von~tuprints,\\
     E-Publishing-Service~der~TU~Darmstadt\\
     \url{http://tuprints.ulb.tu-darmstadt.de}\\


### PR DESCRIPTION
Since tuprints is now also assigning DOI numbers to documents I have added this feature to the the \tuprints command privided by the template. I also added the extended \tuprints command to `DEMO-TUDaPhD.tex` and `DEMO-TUDaThesis`. Can you please doublecheck it?