### PR TITLE
Fix typo in licensing documentation comment

### DIFF
--- a/example/DEMO-TUDaPhD.tex
+++ b/example/DEMO-TUDaPhD.tex
@@ -109,7 +109,7 @@
 % TUDa-CI wird im nächsten größeren Release ebenfalls diese Anpassung vornehmen.
 % Aus diesem Grund wird empfohlen die Lizenz manuell auszuwählen.
 \tuprints{urn=1234,printid=12345,doi=10.25534/tuprints-1234,license=cc-by-4.0}
-% To see furhter information on the license option in English, remove the license= key and pay attention to the warning & help message.
+% To see further information on the license option in English, remove the license= key and pay attention to the warning & help message.
 
 \dedication{For \TeX{} \& Friends}
 

--- a/example/DEMO-TUDaThesis.tex
+++ b/example/DEMO-TUDaThesis.tex
@@ -94,7 +94,7 @@
 % TUDa-CI wird im nächsten größeren Release ebenfalls diese Anpassung vornehmen.
 % Aus diesem Grund wird empfohlen die Lizenz manuell auszuwählen.
 % \tuprints{urn=1234,printid=12345,doi=10.25534/tuprints-1234,license=cc-by-4.0}
-% To see furhter information on the license option in English, remove the license= key and pay attention to the warning & help message.
+% To see further information on the license option in English, remove the license= key and pay attention to the warning & help message.
 
 % \dedication{Für alle, die \TeX{} nutzen.}
 


### PR DESCRIPTION
Corrected `furhter` -> `further` in two comments.