### PR TITLE
Bugfix: \and bei Autordefinition in tudaexercise

### DIFF
--- a/tex/tudaexercise.cls
+++ b/tex/tudaexercise.cls
@@ -539,6 +539,19 @@
 	}
 }
 
+\cs_new:Nn \ptxcd_declare_caption:Nnnn {
+	\ptxcd_define_captionFallback:Nn #1 {#2}
+	\defcaptionname{ngerman, german}{#1}{#2}
+	\defcaptionname{english, USenglish, american}{#1}{#3}
+	\defcaptionname{UKenglish, british}{#1}{#4}
+}
+
+\cs_new:Nn \ptxcd_declare_caption:Nnn {
+	\ptxcd_declare_caption:Nnnn #1 {#2} {#3} {#3}
+}
+
+\ptxcd_declare_caption:Nnn \authorandname {und} {and}
+
 \renewcommand*{\@author}{
 	\seq_use:Nnnn \g_ptxcd_author_seq {~\authorandname{}~} {,~} {~\&~}
       }


### PR DESCRIPTION
Wenn man mehrere Autoren definieren will geht das ja in z.B. tudapub einfach mit:  
```tex
\author{Max Mustermann\and Otto Normalverbraucher}
```
Bei tudaexercise wurde `\authorandname` nicht definiert, sodass ein Fehler geworfen wird.
Dieser PR behebt das Problem.