### PR TITLE
Examples for advanced references with Biber (yearauthor)

### DIFF
--- a/example/DEMO-TUDaBibliography.bib
+++ b/example/DEMO-TUDaBibliography.bib
@@ -41,3 +41,45 @@
 	url={http://mirrors.ctan.org/macros/latex/contrib/tuda-ci/doc/DEMO-TUDaPub.pdf},
 	urldate={2021-10-12}
 }
+
+%% Examples from https://www.overleaf.com/learn/latex/Bibliography_management_with_biblatex
+
+@article{einstein,
+	author =       "Albert Einstein",
+	title =        "{Zur Elektrodynamik bewegter K{\"o}rper}. ({German})
+	[{On} the electrodynamics of moving bodies]",
+	journal =      "Annalen der Physik",
+	volume =       "322",
+	number =       "10",
+	pages =        "891--921",
+	year =         "1905",
+	DOI =          "http://dx.doi.org/10.1002/andp.19053221004",
+	keywords =     "physics"
+}
+
+@book{dirac,
+	title={The Principles of Quantum Mechanics},
+	author={Paul Adrien Maurice Dirac},
+	isbn={9780198520115},
+	series={International series of monographs on physics},
+	year={1981},
+	publisher={Clarendon Press},
+	keywords = {physics}
+}
+
+@online{knuthwebsite,
+	author    = "Donald Knuth",
+	title     = "Knuth: Computers and Typesetting",
+	url       = "http://www-cs-faculty.stanford.edu/~uno/abcde.html",
+	keywords  = "latex,knuth"
+}
+
+@inbook{knuth-fa,
+	author = "Donald E. Knuth",
+	title = "Fundamental Algorithms",
+	publisher = "Addison-Wesley",
+	year = "1973",
+	chapter = "1.2",
+	keywords  = "knuth,programming"
+}
+

--- a/example/DEMO-TUDaThesis.tex
+++ b/example/DEMO-TUDaThesis.tex
@@ -1,3 +1,38 @@
+%% This is file `DEMO-TUDaThesis.tex' version 3.21 (2022/01/11),
+%% it is part of
+%% TUDa-CI -- Corporate Design for TU Darmstadt
+%% ----------------------------------------------------------------------------
+%%
+%%  Copyright (C) 2018--2021 by Marei Peischl <marei@peitex.de>
+%%
+%% ============================================================================
+%% This work may be distributed and/or modified under the
+%% conditions of the LaTeX Project Public License, either version 1.3c
+%% of this license or (at your option) any later version.
+%% The latest version of this license is in
+%% http://www.latex-project.org/lppl.txt
+%% and version 1.3c or later is part of all distributions of LaTeX
+%% version 2008/05/04 or later.
+%%
+%% This work has the LPPL maintenance status `maintained'.
+%%
+%% The Current Maintainers of this work are
+%%   Marei Peischl <tuda-ci@peitex.de>
+%%   Markus Lazanowski <latex@ce.tu-darmstadt.de>
+%%
+%% The development respository can be found at
+%% https://github.com/tudace/tuda_latex_templates
+%% Please use the issue tracker for feedback!
+%%
+%% If you need a compiled version of this document, have a look at
+%% http://mirror.ctan.org/macros/latex/contrib/tuda-ci/doc
+%% or at the documentation directory of this package (if installed)
+%% <path to your LaTeX distribution>/doc/latex/tuda-ci
+%% ============================================================================
+%%
+% !TeX program = lualatex
+%%
+
 \documentclass[
 	ngerman,
 	ruledheaders=section,%Ebene bis zu der die Überschriften mit Linien abgetrennt werden, vgl. DEMO-TUDaPub
@@ -35,6 +70,13 @@
 %%%%%%%%%%%%%%%%%%%
 \usepackage{biblatex}   % Literaturverzeichnis
 \bibliography{DEMO-TUDaBibliography}
+
+% Better bibliography using biber as backend
+%\usepackage[natbib=true,backend=biber,style=authoryear-icomp,maxbibnames=30,maxcitenames=2,uniquelist=false,giveninits=true,doi=false,url=false,dashed=false,isbn=false]{biblatex}
+%\addbibresource{DEMO-TUDaBibliography.bib}
+% Disable "ibid" for repeated citations
+%\boolfalse{citetracker}
+
 
 
 %%%%%%%%%%%%%%%%%%%
@@ -409,6 +451,22 @@ Da es möglich sein kann von dieser Vorgabe abzuweichen, existiert für Sonderf�
 Sofern die Vorgaben es erfordern, ist es möglich mit dem setspace-Paket den Durchschuss zu erhöhen. Allerdings beeinflusst dies natürlich sämtliche Zeilenabstände. Ein erhöhter Zeilenabstand sollte daher erst nach der Titelseite aktiviert werden. Allgemein ist es jedoch empfehlenswert auch für Verzeichnisse und sonstige Sonderelemente außerhalb des Fließtextes auf bei normalen Einstellungen zu bleiben.
 
 Setspace liefert hierfür die Möglichkeit, das Paket ohne Optionen zu laden und später über Makros, wie \code{\tbs{}onehalfspacing} das Umschalten zu verzögern. Alternativ kann auch durch die Umgebungen, wie \code{singlespace} lokal wieder zum Normalzustand gewechselt werden, sofern dies erforderlich ist.
+
+\section{Advanced citation styles}
+
+These work with Biber backend (with natbib) only which is disabled by default. Useful for \texttt{yearname} citation styles.
+
+\begin{verbatim}
+Lorem ipsum \citep{einstein}.
+citet{dirac} discovered lorem ipsum.
+\citeauthor{knuthwebsite}'s approach.
+Lorem ipsum \citep[p.~12]{knuth-fa}.
+\end{verbatim}
+
+% Lorem ipsum \citep{einstein}.
+% \citet{dirac} discovered lorem ipsum.
+% \citeauthor{knuthwebsite}'s approach.
+% Lorem ipsum \citep[p.~12]{knuth-fa}.
 
 \printbibliography
 


### PR DESCRIPTION
Some communities use yearauthor style for citations. Added examples and a possible biblatex configuration with Biber+natbib, disabled by default.