### PR TITLE
Adjusting template to use new DOI/URL/URN naming scheme of tuprints.

### DIFF
--- a/tex/tuda-ci.dtx
+++ b/tex/tuda-ci.dtx
@@ -3294,13 +3294,16 @@
 \keys_define:nn {ptxcd/thesis} {
   urn .tl_gset:N =\g_ptxcd_thesis_urn_tl,
   urn .initial:V = \c_empty_tl,
+  url .tl_gset:N =\g_ptxcd_thesis_url_tl,
+  url .initial:V = \c_empty_tl,
   printid .tl_gset:N = \g_ptxcd_thesis_tuprints_tl,
   printid .initial:V = \c_empty_tl,
 %    \end{macrocode}
 % \changes{v4.02}{2025-03-03}{Add initial setting for doi to use printid.}
 %    \begin{macrocode}
   doi .tl_gset:N = \g_ptxcd_thesis_doi_tl,
-  doi .initial:n = 10.26083/tuprints-\prg_replicate:nn {8 - \tl_count:N \g_ptxcd_thesis_tuprints_tl} {0}\g_ptxcd_thesis_tuprints_tl,
+  doi .initial:n = 10.26083/tuda-\g_ptxcd_thesis_tuprints_tl,
+  % doi .initial:n = 10.26083/tuda-\prg_replicate:nn {8 - \tl_count:N \g_ptxcd_thesis_tuprints_tl} {0}\g_ptxcd_thesis_tuprints_tl,
   year .tl_gset:N = \g_ptxcd_thesis_publication_year_tl,
   year .initial:n = ,
   license .choices:nn = {cc-by-4.0,cc-by-sa-4.0,cc-by-nc-sa-4.0,cc-by-nc-4.0,cc-by-nd-4.0,cc-by-nc-nd-4.0} {
@@ -3378,9 +3381,10 @@ Please~choose~your~license~manually~to~avoid~unintended~changes.
   \lowertitleback{
     \urlstyle{same}
     \selectlanguage{german}
-    Bitte~zitieren~Sie~dieses~Dokument~als:
-    \tl_if_empty:NF \g_ptxcd_thesis_urn_tl {\\URN:~urn:nbn:de:tuda-tuprints-\g_ptxcd_thesis_urn_tl}\\
+    Bitte~zitieren~Sie~dieses~Dokument~als:\\
     \tl_if_empty:NF \g_ptxcd_thesis_doi_tl {DOI:~\url{https://doi.org/\g_ptxcd_thesis_doi_tl}\\}
+    \tl_if_empty:NF \g_ptxcd_thesis_url_tl {URL:~\url{https://tuprints.ulb.tu-darmstadt.de/handle/tuda/\g_ptxcd_thesis_url_tl}\\}
+    \tl_if_empty:NF \g_ptxcd_thesis_urn_tl {URN:~\url{https://nbn-resolving.de/urn:nbn:de:tuda-tuda-\g_ptxcd_thesis_urn_tl}\\}
     \tl_if_empty:NF \g_ptxcd_thesis_publication_year_tl {Jahr~der~Veröffentlichung~auf~TUprints:~\g_ptxcd_thesis_publication_year_tl}
     \par\vspace{\baselineskip}
     Dieses~Dokument~wird~bereitgestellt~von~tuprints,\\


### PR DESCRIPTION
Hi folks,

As discussed in #520, tuprints has introduced a new naming scheme as follows (including the order):

* DOI: https://doi.org/10.26083/tuda-1234
* URL: https://tuprints.ulb.tu-darmstadt.de/handle/tuda/56789
* URN: https://nbn-resolving.de/urn:nbn:de:tuda-tuda-567890

Since I am about to publish my dissertation, I needed a *quick fix* that works for now. I am sharing this here for other "fellow sufferers" who may be affected.

It may not be complete or technically versatile, so feel free to adapt it. I use LaTeX directly on my local machine, not ShareLaTeX/Overleaf, just FYI.

@TeXhackse: Thanks for the awesome template. 😃

This PR fixes #520.